### PR TITLE
feat: add Customer CRUD API (#7)

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -61,15 +61,16 @@ model User {
 }
 
 model Customer {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   name      String
   phone     String?
   email     String?
   address   String?
-  notes     String?
+  notes     String?   @db.Text
   storeId   String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime?
 
   store        Store         @relation(fields: [storeId], references: [id])
   tags         Tag[]         @relation("CustomerTags")

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import { requestLogger } from './middleware/requestLogger';
 import { errorHandler } from './middleware/errorHandler';
 import storeRoutes from './routes/store.routes';
+import customerRoutes from './routes/customer.routes';
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ app.get('/api/health', (_req, res) => {
 
 // API routes
 app.use('/api/stores', storeRoutes);
+app.use('/api/customers', customerRoutes);
 
 // Error handling (must be after routes)
 app.use(errorHandler);

--- a/packages/backend/src/controllers/customer.controller.ts
+++ b/packages/backend/src/controllers/customer.controller.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from 'express';
+import * as customerService from '../services/customer.service';
+import {
+  createCustomerSchema,
+  updateCustomerSchema,
+  listCustomersSchema,
+} from '../validators/customer.validator';
+import { ValidationError } from '../utils/errors';
+
+export async function create(req: Request, res: Response): Promise<void> {
+  const parsed = createCustomerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid input', parsed.error.flatten().fieldErrors);
+  }
+
+  const { customer, warnings } = await customerService.createCustomer(parsed.data);
+  res.status(201).json({ data: customer, ...(warnings.length > 0 && { warnings }) });
+}
+
+export async function list(req: Request, res: Response): Promise<void> {
+  const parsed = listCustomersSchema.safeParse(req.query);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid query parameters', parsed.error.flatten().fieldErrors);
+  }
+
+  const { customers, meta } = await customerService.listCustomers(parsed.data);
+  res.json({ data: customers, meta });
+}
+
+export async function getById(req: Request, res: Response): Promise<void> {
+  const customer = await customerService.getCustomerById(req.params.id);
+  res.json({ data: customer });
+}
+
+export async function update(req: Request, res: Response): Promise<void> {
+  const parsed = updateCustomerSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid input', parsed.error.flatten().fieldErrors);
+  }
+
+  const { customer, warnings } = await customerService.updateCustomer(
+    req.params.id,
+    parsed.data,
+  );
+  res.json({ data: customer, ...(warnings.length > 0 && { warnings }) });
+}
+
+export async function remove(req: Request, res: Response): Promise<void> {
+  await customerService.deleteCustomer(req.params.id);
+  res.status(204).send();
+}

--- a/packages/backend/src/routes/__tests__/customer.routes.test.ts
+++ b/packages/backend/src/routes/__tests__/customer.routes.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+// ── Mock Prisma (vi.hoisted so mock is available at hoist time) ──
+const mockCustomer = vi.hoisted(() => ({
+  create: vi.fn(),
+  findMany: vi.fn(),
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock('../../prismaClient', () => ({
+  prisma: { customer: mockCustomer },
+}));
+
+// Import app after mock setup
+import { app } from '../../app';
+
+// ── Fixtures ───────────────────────────────────────────
+const fakeCustomer = {
+  id: 'cust_abc123',
+  name: 'John Doe',
+  phone: '+1234567890',
+  email: 'john@example.com',
+  address: '456 Oak Ave',
+  notes: 'VIP customer',
+  storeId: 'store_xyz',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  deletedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── POST /api/customers ──────────────────────────────
+describe('POST /api/customers', () => {
+  it('should create a customer and return 201', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null); // no duplicates
+    mockCustomer.create.mockResolvedValue(fakeCustomer);
+
+    const res = await request(app)
+      .post('/api/customers')
+      .send({
+        name: 'John Doe',
+        phone: '+1234567890',
+        email: 'john@example.com',
+        address: '456 Oak Ave',
+        notes: 'VIP customer',
+        storeId: 'store_xyz',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toEqual({ ...fakeCustomer, tags: [] });
+  });
+
+  it('should return 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ storeId: 'store_xyz' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.details).toBeDefined();
+  });
+
+  it('should return 400 when storeId is missing', async () => {
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'John Doe' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for invalid email format', async () => {
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'John', storeId: 'store_xyz', email: 'not-an-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for invalid phone format', async () => {
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'John', storeId: 'store_xyz', phone: 'abc' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when name is empty string', async () => {
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: '', storeId: 'store_xyz' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should create with name and storeId only', async () => {
+    const minimal = { ...fakeCustomer, phone: null, email: null, address: null, notes: null };
+    mockCustomer.create.mockResolvedValue(minimal);
+
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'John Doe', storeId: 'store_xyz' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('John Doe');
+    expect(res.body.data.tags).toEqual([]);
+  });
+
+  it('should include duplicate warnings in response', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer); // duplicate found
+    mockCustomer.create.mockResolvedValue(fakeCustomer);
+
+    const res = await request(app)
+      .post('/api/customers')
+      .send({
+        name: 'Jane Doe',
+        phone: '+1234567890',
+        email: 'john@example.com',
+        storeId: 'store_xyz',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.warnings).toBeDefined();
+    expect(res.body.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('should not include warnings key when no duplicates', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+    mockCustomer.create.mockResolvedValue(fakeCustomer);
+
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'John Doe', storeId: 'store_xyz' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.warnings).toBeUndefined();
+  });
+});
+
+// ── GET /api/customers ───────────────────────────────
+describe('GET /api/customers', () => {
+  it('should return paginated customers with meta', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    const res = await request(app).get('/api/customers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([{ ...fakeCustomer, tags: [] }]);
+    expect(res.body.meta).toEqual({
+      page: 1,
+      limit: 20,
+      total: 1,
+      totalPages: 1,
+    });
+  });
+
+  it('should respect page and limit query params', async () => {
+    mockCustomer.count.mockResolvedValue(50);
+    mockCustomer.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/customers?page=3&limit=10');
+
+    expect(res.status).toBe(200);
+    expect(res.body.meta.page).toBe(3);
+    expect(res.body.meta.limit).toBe(10);
+    expect(res.body.meta.total).toBe(50);
+    expect(res.body.meta.totalPages).toBe(5);
+  });
+
+  it('should return 400 for invalid pagination params', async () => {
+    const res = await request(app).get('/api/customers?page=-1');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return empty array when no customers exist', async () => {
+    mockCustomer.count.mockResolvedValue(0);
+    mockCustomer.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get('/api/customers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.total).toBe(0);
+  });
+
+  it('should search across name, phone, email', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    const res = await request(app).get('/api/customers?search=john');
+
+    expect(res.status).toBe(200);
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { name: { contains: 'john', mode: 'insensitive' } },
+            { phone: { contains: 'john', mode: 'insensitive' } },
+            { email: { contains: 'john', mode: 'insensitive' } },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it('should sort by name ascending', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    const res = await request(app).get('/api/customers?sortBy=name&order=asc');
+
+    expect(res.status).toBe(200);
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { name: 'asc' },
+      }),
+    );
+  });
+
+  it('should filter by storeId', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    const res = await request(app).get('/api/customers?storeId=store_xyz');
+
+    expect(res.status).toBe(200);
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ storeId: 'store_xyz' }),
+      }),
+    );
+  });
+
+  it('should return 400 for invalid sortBy value', async () => {
+    const res = await request(app).get('/api/customers?sortBy=invalid');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ── GET /api/customers/:id ───────────────────────────
+describe('GET /api/customers/:id', () => {
+  it('should return a customer by id with tags', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+
+    const res = await request(app).get('/api/customers/cust_abc123');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ ...fakeCustomer, tags: [] });
+  });
+
+  it('should return 404 when customer not found', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/customers/nonexistent');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+    expect(res.body.error.message).toContain('nonexistent');
+  });
+});
+
+// ── PUT /api/customers/:id ───────────────────────────
+describe('PUT /api/customers/:id', () => {
+  it('should update a customer', async () => {
+    const updated = { ...fakeCustomer, name: 'Jane Doe' };
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put('/api/customers/cust_abc123')
+      .send({ name: 'Jane Doe' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('Jane Doe');
+    expect(res.body.data.tags).toEqual([]);
+  });
+
+  it('should return 404 when updating non-existent customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/customers/nonexistent')
+      .send({ name: 'Updated' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 for invalid phone on update', async () => {
+    const res = await request(app)
+      .put('/api/customers/cust_abc123')
+      .send({ phone: 'not-a-phone' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for invalid email on update', async () => {
+    const res = await request(app)
+      .put('/api/customers/cust_abc123')
+      .send({ email: 'bad-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should allow clearing nullable fields with null', async () => {
+    const cleared = { ...fakeCustomer, phone: null, email: null };
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue(cleared);
+
+    const res = await request(app)
+      .put('/api/customers/cust_abc123')
+      .send({ phone: null, email: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.phone).toBeNull();
+    expect(res.body.data.email).toBeNull();
+  });
+
+  it('should include duplicate warnings on update', async () => {
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // getById
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // duplicate check
+    mockCustomer.update.mockResolvedValue(fakeCustomer);
+
+    const res = await request(app)
+      .put('/api/customers/cust_abc123')
+      .send({ phone: '+1234567890' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeDefined();
+  });
+});
+
+// ── DELETE /api/customers/:id ────────────────────────
+describe('DELETE /api/customers/:id', () => {
+  it('should soft-delete a customer and return 204', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue({ ...fakeCustomer, deletedAt: new Date() });
+
+    const res = await request(app).delete('/api/customers/cust_abc123');
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it('should return 404 when deleting non-existent customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).delete('/api/customers/nonexistent');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+// ── Error handling ────────────────────────────────────
+describe('Error handling', () => {
+  it('should return 500 for unexpected errors', async () => {
+    mockCustomer.count.mockRejectedValue(new Error('DB connection failed'));
+
+    const res = await request(app).get('/api/customers');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+    expect(res.body.error.message).toBe('An unexpected error occurred');
+  });
+
+  it('should return consistent error format', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/customers/nonexistent');
+
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toHaveProperty('code');
+    expect(res.body.error).toHaveProperty('message');
+  });
+});

--- a/packages/backend/src/routes/customer.routes.ts
+++ b/packages/backend/src/routes/customer.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import * as customerController from '../controllers/customer.controller';
+import { asyncHandler } from '../utils/asyncHandler';
+
+const router = Router();
+
+router.post('/', asyncHandler(customerController.create));
+router.get('/', asyncHandler(customerController.list));
+router.get('/:id', asyncHandler(customerController.getById));
+router.put('/:id', asyncHandler(customerController.update));
+router.delete('/:id', asyncHandler(customerController.remove));
+
+export default router;

--- a/packages/backend/src/schema.test.ts
+++ b/packages/backend/src/schema.test.ts
@@ -144,7 +144,7 @@ describe('User fields', () => {
 describe('Customer fields', () => {
   const fields = fieldsOf(Prisma.CustomerScalarFieldEnum);
 
-  it('should have id, name, phone, email, address, notes, storeId, createdAt, updatedAt', () => {
+  it('should have id, name, phone, email, address, notes, storeId, createdAt, updatedAt, deletedAt', () => {
     expect(fields).toEqual(
       expect.arrayContaining([
         'id',
@@ -156,12 +156,13 @@ describe('Customer fields', () => {
         'storeId',
         'createdAt',
         'updatedAt',
+        'deletedAt',
       ]),
     );
   });
 
-  it('should have exactly 9 scalar fields', () => {
-    expect(fields).toHaveLength(9);
+  it('should have exactly 10 scalar fields', () => {
+    expect(fields).toHaveLength(10);
   });
 });
 

--- a/packages/backend/src/services/__tests__/customer.service.test.ts
+++ b/packages/backend/src/services/__tests__/customer.service.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotFoundError } from '../../utils/errors';
+
+// ── Mock Prisma (vi.hoisted so mock is available at hoist time) ──
+const mockCustomer = vi.hoisted(() => ({
+  create: vi.fn(),
+  findMany: vi.fn(),
+  findFirst: vi.fn(),
+  update: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock('../../prismaClient', () => ({
+  prisma: { customer: mockCustomer },
+}));
+
+// Import after mock setup
+import {
+  createCustomer,
+  listCustomers,
+  getCustomerById,
+  updateCustomer,
+  deleteCustomer,
+  checkDuplicates,
+} from '../customer.service';
+
+// ── Fixtures ───────────────────────────────────────────
+const fakeCustomer = {
+  id: 'cust_abc123',
+  name: 'John Doe',
+  phone: '+1234567890',
+  email: 'john@example.com',
+  address: '456 Oak Ave',
+  notes: 'VIP customer',
+  storeId: 'store_xyz',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  deletedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── checkDuplicates ───────────────────────────────────
+describe('checkDuplicates', () => {
+  it('should return empty warnings when no duplicates', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const warnings = await checkDuplicates('store_xyz', '+1234567890', 'john@example.com');
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('should warn when phone already exists in same store', async () => {
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // phone match
+    mockCustomer.findFirst.mockResolvedValueOnce(null);          // email no match
+
+    const warnings = await checkDuplicates('store_xyz', '+1234567890', 'other@example.com');
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('phone');
+  });
+
+  it('should warn when email already exists in same store', async () => {
+    mockCustomer.findFirst.mockResolvedValueOnce(null);          // phone no match
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // email match
+
+    const warnings = await checkDuplicates('store_xyz', '+9999999999', 'john@example.com');
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].field).toBe('email');
+  });
+
+  it('should warn for both phone and email duplicates', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+
+    const warnings = await checkDuplicates('store_xyz', '+1234567890', 'john@example.com');
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((w) => w.field)).toEqual(['phone', 'email']);
+  });
+
+  it('should skip check when phone/email not provided', async () => {
+    const warnings = await checkDuplicates('store_xyz', undefined, undefined);
+
+    expect(warnings).toEqual([]);
+    expect(mockCustomer.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('should skip check for null phone/email', async () => {
+    const warnings = await checkDuplicates('store_xyz', null, null);
+
+    expect(warnings).toEqual([]);
+    expect(mockCustomer.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('should exclude current customer id when checking for updates', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await checkDuplicates('store_xyz', '+1234567890', null, 'cust_abc123');
+
+    expect(mockCustomer.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: { not: 'cust_abc123' },
+      }),
+    });
+  });
+});
+
+// ── createCustomer ────────────────────────────────────
+describe('createCustomer', () => {
+  it('should create a customer with valid data', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null); // no duplicates
+    mockCustomer.create.mockResolvedValue(fakeCustomer);
+
+    const result = await createCustomer({
+      name: 'John Doe',
+      phone: '+1234567890',
+      email: 'john@example.com',
+      address: '456 Oak Ave',
+      notes: 'VIP customer',
+      storeId: 'store_xyz',
+    });
+
+    expect(mockCustomer.create).toHaveBeenCalledWith({
+      data: {
+        name: 'John Doe',
+        phone: '+1234567890',
+        email: 'john@example.com',
+        address: '456 Oak Ave',
+        notes: 'VIP customer',
+        storeId: 'store_xyz',
+      },
+    });
+    expect(result.customer).toEqual({ ...fakeCustomer, tags: [] });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('should create with name and storeId only (optional fields omitted)', async () => {
+    const minimal = { ...fakeCustomer, phone: null, email: null, address: null, notes: null };
+    mockCustomer.create.mockResolvedValue(minimal);
+
+    const result = await createCustomer({ name: 'John Doe', storeId: 'store_xyz' });
+
+    expect(mockCustomer.create).toHaveBeenCalledWith({
+      data: { name: 'John Doe', storeId: 'store_xyz' },
+    });
+    expect(result.customer.tags).toEqual([]);
+  });
+
+  it('should return duplicate warnings but still create', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer); // both phone & email duplicate
+    mockCustomer.create.mockResolvedValue(fakeCustomer);
+
+    const result = await createCustomer({
+      name: 'Jane Doe',
+      phone: '+1234567890',
+      email: 'john@example.com',
+      storeId: 'store_xyz',
+    });
+
+    expect(result.warnings).toHaveLength(2);
+    expect(result.customer).toBeDefined();
+  });
+});
+
+// ── listCustomers ─────────────────────────────────────
+describe('listCustomers', () => {
+  it('should return paginated customers with meta', async () => {
+    mockCustomer.count.mockResolvedValue(25);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    const result = await listCustomers({
+      page: 2,
+      limit: 10,
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.count).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+    });
+    expect(mockCustomer.findMany).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+      skip: 10,
+      take: 10,
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(result.meta).toEqual({
+      page: 2,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+    });
+    expect(result.customers).toEqual([{ ...fakeCustomer, tags: [] }]);
+  });
+
+  it('should use default pagination (page 1, limit 20)', async () => {
+    mockCustomer.count.mockResolvedValue(0);
+    mockCustomer.findMany.mockResolvedValue([]);
+
+    const result = await listCustomers({
+      page: 1,
+      limit: 20,
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0, take: 20 }),
+    );
+    expect(result.meta.totalPages).toBe(0);
+    expect(result.customers).toEqual([]);
+  });
+
+  it('should filter by storeId', async () => {
+    mockCustomer.count.mockResolvedValue(5);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    await listCustomers({
+      page: 1,
+      limit: 20,
+      storeId: 'store_xyz',
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.count).toHaveBeenCalledWith({
+      where: { deletedAt: null, storeId: 'store_xyz' },
+    });
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { deletedAt: null, storeId: 'store_xyz' },
+      }),
+    );
+  });
+
+  it('should apply search across name, phone, email', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    await listCustomers({
+      page: 1,
+      limit: 20,
+      search: 'john',
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.count).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        OR: [
+          { name: { contains: 'john', mode: 'insensitive' } },
+          { phone: { contains: 'john', mode: 'insensitive' } },
+          { email: { contains: 'john', mode: 'insensitive' } },
+        ],
+      },
+    });
+  });
+
+  it('should sort by specified field and order', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    await listCustomers({
+      page: 1,
+      limit: 20,
+      sortBy: 'name',
+      order: 'asc',
+    });
+
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { name: 'asc' },
+      }),
+    );
+  });
+
+  it('should exclude soft-deleted customers', async () => {
+    mockCustomer.count.mockResolvedValue(0);
+    mockCustomer.findMany.mockResolvedValue([]);
+
+    await listCustomers({
+      page: 1,
+      limit: 20,
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ deletedAt: null }),
+      }),
+    );
+  });
+
+  it('should combine search and storeId filters', async () => {
+    mockCustomer.count.mockResolvedValue(1);
+    mockCustomer.findMany.mockResolvedValue([fakeCustomer]);
+
+    await listCustomers({
+      page: 1,
+      limit: 20,
+      search: 'john',
+      storeId: 'store_xyz',
+      sortBy: 'createdAt',
+      order: 'desc',
+    });
+
+    expect(mockCustomer.count).toHaveBeenCalledWith({
+      where: {
+        deletedAt: null,
+        storeId: 'store_xyz',
+        OR: [
+          { name: { contains: 'john', mode: 'insensitive' } },
+          { phone: { contains: 'john', mode: 'insensitive' } },
+          { email: { contains: 'john', mode: 'insensitive' } },
+        ],
+      },
+    });
+  });
+});
+
+// ── getCustomerById ───────────────────────────────────
+describe('getCustomerById', () => {
+  it('should return a customer with tags when found', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+
+    const result = await getCustomerById('cust_abc123');
+
+    expect(mockCustomer.findFirst).toHaveBeenCalledWith({
+      where: { id: 'cust_abc123', deletedAt: null },
+    });
+    expect(result).toEqual({ ...fakeCustomer, tags: [] });
+  });
+
+  it('should throw NotFoundError when customer does not exist', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(getCustomerById('nonexistent')).rejects.toThrow(NotFoundError);
+    await expect(getCustomerById('nonexistent')).rejects.toThrow(
+      "Customer with id 'nonexistent' not found",
+    );
+  });
+
+  it('should throw NotFoundError for a soft-deleted customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(getCustomerById('deleted_id')).rejects.toThrow(NotFoundError);
+  });
+});
+
+// ── updateCustomer ────────────────────────────────────
+describe('updateCustomer', () => {
+  it('should update an existing customer', async () => {
+    const updated = { ...fakeCustomer, name: 'Jane Doe' };
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue(updated);
+
+    const result = await updateCustomer('cust_abc123', { name: 'Jane Doe' });
+
+    expect(mockCustomer.findFirst).toHaveBeenCalledWith({
+      where: { id: 'cust_abc123', deletedAt: null },
+    });
+    expect(mockCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'cust_abc123' },
+      data: { name: 'Jane Doe' },
+    });
+    expect(result.customer.name).toBe('Jane Doe');
+    expect(result.customer.tags).toEqual([]);
+  });
+
+  it('should throw NotFoundError when updating non-existent customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(updateCustomer('nonexistent', { name: 'X' })).rejects.toThrow(NotFoundError);
+    expect(mockCustomer.update).not.toHaveBeenCalled();
+  });
+
+  it('should allow setting nullable fields to null', async () => {
+    const cleared = { ...fakeCustomer, phone: null };
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue(cleared);
+
+    const result = await updateCustomer('cust_abc123', { phone: null });
+
+    expect(mockCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'cust_abc123' },
+      data: { phone: null },
+    });
+    expect(result.customer.phone).toBeNull();
+  });
+
+  it('should return duplicate warnings on update', async () => {
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // getById check
+    mockCustomer.findFirst.mockResolvedValueOnce(fakeCustomer); // duplicate phone check
+    mockCustomer.update.mockResolvedValue(fakeCustomer);
+
+    const result = await updateCustomer('cust_abc123', { phone: '+1234567890' });
+
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── deleteCustomer ────────────────────────────────────
+describe('deleteCustomer', () => {
+  it('should soft-delete an existing customer by setting deletedAt', async () => {
+    const deleted = { ...fakeCustomer, deletedAt: new Date() };
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+    mockCustomer.update.mockResolvedValue(deleted);
+
+    const result = await deleteCustomer('cust_abc123');
+
+    expect(mockCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'cust_abc123' },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(result.deletedAt).not.toBeNull();
+  });
+
+  it('should throw NotFoundError when deleting non-existent customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(deleteCustomer('nonexistent')).rejects.toThrow(NotFoundError);
+    expect(mockCustomer.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundError when deleting already-deleted customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(deleteCustomer('already_deleted')).rejects.toThrow(NotFoundError);
+  });
+});

--- a/packages/backend/src/services/customer.service.ts
+++ b/packages/backend/src/services/customer.service.ts
@@ -1,0 +1,151 @@
+import { prisma } from '../prismaClient';
+import {
+  CreateCustomerInput,
+  UpdateCustomerInput,
+  ListCustomersQuery,
+} from '../validators/customer.validator';
+import { NotFoundError } from '../utils/errors';
+import { buildPagination } from '../utils/pagination';
+
+/** Condition that excludes soft-deleted records. */
+const notDeleted = { deletedAt: null };
+
+export interface DuplicateWarning {
+  field: 'phone' | 'email';
+  message: string;
+}
+
+/**
+ * Check for duplicate phone or email within the same store.
+ * Returns warnings (not hard blocks) per the spec.
+ */
+export async function checkDuplicates(
+  storeId: string,
+  phone?: string | null,
+  email?: string | null,
+  excludeId?: string,
+): Promise<DuplicateWarning[]> {
+  const warnings: DuplicateWarning[] = [];
+
+  if (phone) {
+    const existing = await prisma.customer.findFirst({
+      where: {
+        storeId,
+        phone,
+        ...notDeleted,
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+    });
+    if (existing) {
+      warnings.push({
+        field: 'phone',
+        message: `A customer with phone '${phone}' already exists in this store`,
+      });
+    }
+  }
+
+  if (email) {
+    const existing = await prisma.customer.findFirst({
+      where: {
+        storeId,
+        email,
+        ...notDeleted,
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+    });
+    if (existing) {
+      warnings.push({
+        field: 'email',
+        message: `A customer with email '${email}' already exists in this store`,
+      });
+    }
+  }
+
+  return warnings;
+}
+
+export async function createCustomer(data: CreateCustomerInput) {
+  const warnings = await checkDuplicates(data.storeId, data.phone, data.email);
+
+  const customer = await prisma.customer.create({
+    data,
+  });
+
+  return { customer: { ...customer, tags: [] }, warnings };
+}
+
+export async function listCustomers(query: ListCustomersQuery) {
+  const { page, limit, search, sortBy, order, storeId } = query;
+
+  // Build where clause
+  const where: Record<string, unknown> = { ...notDeleted };
+
+  if (storeId) {
+    where.storeId = storeId;
+  }
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { phone: { contains: search, mode: 'insensitive' } },
+      { email: { contains: search, mode: 'insensitive' } },
+    ];
+  }
+
+  const total = await prisma.customer.count({ where });
+  const { skip, take, meta } = buildPagination({ page, limit }, total);
+
+  const customers = await prisma.customer.findMany({
+    where,
+    skip,
+    take,
+    orderBy: { [sortBy]: order },
+  });
+
+  // Append empty tags array to each customer
+  const customersWithTags = customers.map((c) => ({ ...c, tags: [] }));
+
+  return { customers: customersWithTags, meta };
+}
+
+export async function getCustomerById(id: string) {
+  const customer = await prisma.customer.findFirst({
+    where: { id, ...notDeleted },
+  });
+
+  if (!customer) {
+    throw new NotFoundError('Customer', id);
+  }
+
+  return { ...customer, tags: [] };
+}
+
+export async function updateCustomer(id: string, data: UpdateCustomerInput) {
+  // Verify exists and not deleted
+  const existing = await getCustomerById(id);
+
+  // Check duplicates for the updated fields
+  const warnings = await checkDuplicates(
+    existing.storeId,
+    data.phone !== undefined ? data.phone : undefined,
+    data.email !== undefined ? data.email : undefined,
+    id,
+  );
+
+  const customer = await prisma.customer.update({
+    where: { id },
+    data,
+  });
+
+  return { customer: { ...customer, tags: [] }, warnings };
+}
+
+export async function deleteCustomer(id: string) {
+  // Verify exists and not deleted
+  await getCustomerById(id);
+
+  return prisma.customer.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
+}

--- a/packages/backend/src/validators/customer.validator.ts
+++ b/packages/backend/src/validators/customer.validator.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+/**
+ * Phone: optional, but if provided must be a reasonable phone format.
+ * Reuses the same regex pattern as store validator.
+ */
+const phoneRegex = /^[+]?[\d\s()-]{7,20}$/;
+
+export const createCustomerSchema = z.object({
+  name: z.string().trim().min(1, 'Customer name is required').max(200),
+  phone: z
+    .string()
+    .trim()
+    .regex(phoneRegex, 'Invalid phone format')
+    .optional(),
+  email: z
+    .string()
+    .trim()
+    .email('Invalid email format')
+    .max(254)
+    .optional(),
+  address: z.string().trim().max(500).optional(),
+  notes: z.string().trim().max(5000).optional(),
+  storeId: z.string().trim().min(1, 'Store ID is required'),
+});
+
+export const updateCustomerSchema = z.object({
+  name: z.string().trim().min(1, 'Customer name is required').max(200).optional(),
+  phone: z
+    .string()
+    .trim()
+    .regex(phoneRegex, 'Invalid phone format')
+    .nullable()
+    .optional(),
+  email: z
+    .string()
+    .trim()
+    .email('Invalid email format')
+    .max(254)
+    .nullable()
+    .optional(),
+  address: z.string().trim().max(500).nullable().optional(),
+  notes: z.string().trim().max(5000).nullable().optional(),
+});
+
+/**
+ * Query params for listing customers.
+ * Extends pagination with search and sort capabilities.
+ */
+export const listCustomersSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  search: z.string().trim().max(200).optional(),
+  sortBy: z.enum(['name', 'email', 'phone', 'createdAt']).default('createdAt'),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  storeId: z.string().trim().min(1).optional(),
+});
+
+export type CreateCustomerInput = z.infer<typeof createCustomerSchema>;
+export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>;
+export type ListCustomersQuery = z.infer<typeof listCustomersSchema>;


### PR DESCRIPTION
## Summary
- Implement full Customer CRUD API (`POST/GET/PUT/DELETE /api/customers`) with Zod input validation, soft delete, pagination, search (name/phone/email via Prisma `contains` insensitive), and sort (`sortBy` + `order` params)
- Add duplicate detection — returns `warnings` array when phone or email already exists in the same store (soft warning, not a hard block)
- Every response includes `tags: []` placeholder for the future tagging system
- Add `deletedAt` column to Customer model and `@db.Text` annotation on `notes` field in Prisma schema

## Files Changed
| File | Change |
|------|--------|
| `prisma/schema.prisma` | Add `deletedAt DateTime?` and `@db.Text` to Customer model |
| `src/validators/customer.validator.ts` | Zod schemas for create, update, and list query params |
| `src/services/customer.service.ts` | Business logic — CRUD, search, sort, pagination, duplicate detection |
| `src/controllers/customer.controller.ts` | Request parsing, validation, response formatting |
| `src/routes/customer.routes.ts` | RESTful route definitions |
| `src/app.ts` | Mount customer routes at `/api/customers` |
| `src/schema.test.ts` | Update Customer field count assertion (9→10 for `deletedAt`) |
| `src/services/__tests__/customer.service.test.ts` | 27 unit tests for service layer |
| `src/routes/__tests__/customer.routes.test.ts` | 29 integration tests for all routes |

## Test plan
- [x] 127 tests pass (56 new + 71 existing)
- [x] Service unit tests: CRUD, search, sort, pagination, duplicate detection, edge cases
- [x] Route integration tests: all endpoints, validation errors, 404s, 500 handling, duplicate warnings
- [x] Self-check: no debug code, no TODOs, no hardcoded URLs

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)