### PR TITLE
feat: customer tagging system (#9)

### DIFF
--- a/packages/backend/prisma/migrations/20260408000000_add_tag_unique_name_per_store/migration.sql
+++ b/packages/backend/prisma/migrations/20260408000000_add_tag_unique_name_per_store/migration.sql
@@ -1,0 +1,4 @@
+-- Add unique constraint on Tag(storeId, name) — tag names are unique
+-- within a store. Two different stores may both have a "VIP" tag,
+-- but a single store cannot have two tags named "VIP".
+CREATE UNIQUE INDEX "Tag_storeId_name_key" ON "Tag"("storeId", "name");

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -107,6 +107,9 @@ model Tag {
   store     Store      @relation(fields: [storeId], references: [id])
   customers Customer[] @relation("CustomerTags")
 
+  // Tag names are unique within a store — two stores can both have a "VIP" tag,
+  // but a single store cannot have two tags named "VIP".
+  @@unique([storeId, name])
   @@index([storeId])
 }
 

--- a/packages/backend/prisma/seed.ts
+++ b/packages/backend/prisma/seed.ts
@@ -47,16 +47,19 @@ async function main() {
   });
 
   // ── Tags ───────────────────────────────────
+  // Predefined tags every store gets out of the box. Names are unique
+  // per store via @@unique([storeId, name]); colors are hex strings so
+  // the frontend can render them however it likes.
   const tagVIP = await prisma.tag.create({
-    data: { name: 'VIP', color: '#FFD700', storeId: store.id },
+    data: { name: 'VIP', color: '#FFD700', storeId: store.id }, // gold
   });
 
-  const tagNewComer = await prisma.tag.create({
-    data: { name: 'Newcomer', color: '#87CEEB', storeId: store.id },
+  const tagRegular = await prisma.tag.create({
+    data: { name: 'Regular', color: '#1E90FF', storeId: store.id }, // blue
   });
 
-  const tagFrequent = await prisma.tag.create({
-    data: { name: 'Frequent', color: '#90EE90', storeId: store.id },
+  const tagNew = await prisma.tag.create({
+    data: { name: 'New', color: '#32CD32', storeId: store.id }, // green
   });
 
   // ── Customers (5) ─────────────────────────
@@ -69,7 +72,7 @@ async function main() {
         address: '456 Oak Ave',
         notes: 'Prefers weekend visits',
         storeId: store.id,
-        tags: { connect: [{ id: tagVIP.id }, { id: tagFrequent.id }] },
+        tags: { connect: [{ id: tagVIP.id }, { id: tagRegular.id }] },
       },
     }),
     prisma.customer.create({
@@ -79,7 +82,7 @@ async function main() {
         email: 'diana@example.com',
         address: '789 Pine Rd',
         storeId: store.id,
-        tags: { connect: [{ id: tagNewComer.id }] },
+        tags: { connect: [{ id: tagNew.id }] },
       },
     }),
     prisma.customer.create({
@@ -88,7 +91,7 @@ async function main() {
         phone: '0912-333-333',
         email: 'edward@example.com',
         storeId: store.id,
-        tags: { connect: [{ id: tagFrequent.id }] },
+        tags: { connect: [{ id: tagRegular.id }] },
       },
     }),
     prisma.customer.create({

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -6,6 +6,7 @@ import { errorHandler } from './middleware/errorHandler';
 import storeRoutes from './routes/store.routes';
 import authRoutes from './routes/auth.routes';
 import customerRoutes from './routes/customer.routes';
+import tagRoutes from './routes/tag.routes';
 
 dotenv.config();
 
@@ -29,6 +30,7 @@ app.get('/api/health', (_req, res) => {
 app.use('/api/auth', authRoutes);
 app.use('/api/stores', storeRoutes);
 app.use('/api/customers', customerRoutes);
+app.use('/api/tags', tagRoutes);
 
 // Error handling (must be after routes)
 app.use(errorHandler);

--- a/packages/backend/src/controllers/tag.controller.ts
+++ b/packages/backend/src/controllers/tag.controller.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from 'express';
+import * as tagService from '../services/tag.service';
+import {
+  createTagSchema,
+  updateTagSchema,
+  assignTagsSchema,
+  listTagsQuerySchema,
+} from '../validators/tag.validator';
+import { ValidationError } from '../utils/errors';
+
+export async function create(req: Request, res: Response): Promise<void> {
+  const parsed = createTagSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid input', parsed.error.flatten().fieldErrors);
+  }
+
+  const tag = await tagService.createTag(parsed.data);
+  res.status(201).json({ data: tag });
+}
+
+export async function list(req: Request, res: Response): Promise<void> {
+  const parsed = listTagsQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    throw new ValidationError(
+      'Invalid query parameters',
+      parsed.error.flatten().fieldErrors,
+    );
+  }
+
+  const tags = await tagService.listTagsByStore(parsed.data.storeId);
+  res.json({ data: tags });
+}
+
+export async function update(req: Request, res: Response): Promise<void> {
+  const parsed = updateTagSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid input', parsed.error.flatten().fieldErrors);
+  }
+
+  const tag = await tagService.updateTag(req.params.id, parsed.data);
+  res.json({ data: tag });
+}
+
+export async function remove(req: Request, res: Response): Promise<void> {
+  await tagService.deleteTag(req.params.id);
+  res.status(204).send();
+}
+
+// ── Customer-tag assignment endpoints ─────────────────
+
+export async function assignToCustomer(req: Request, res: Response): Promise<void> {
+  const parsed = assignTagsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw new ValidationError('Invalid input', parsed.error.flatten().fieldErrors);
+  }
+
+  const tags = await tagService.assignTagsToCustomer(
+    req.params.id,
+    parsed.data.tagIds,
+  );
+  res.status(200).json({ data: { tags } });
+}
+
+export async function removeFromCustomer(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const tags = await tagService.removeTagFromCustomer(
+    req.params.id,
+    req.params.tagId,
+  );
+  res.status(200).json({ data: { tags } });
+}

--- a/packages/backend/src/routes/__tests__/tag.routes.test.ts
+++ b/packages/backend/src/routes/__tests__/tag.routes.test.ts
@@ -1,0 +1,584 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+
+// ── Mock Prisma (vi.hoisted so mock is available at hoist time) ──
+const mockTag = vi.hoisted(() => ({
+  create: vi.fn(),
+  findMany: vi.fn(),
+  findUnique: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}));
+
+const mockCustomer = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockUser = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+}));
+
+vi.mock('../../prismaClient', () => ({
+  prisma: { tag: mockTag, customer: mockCustomer, user: mockUser },
+}));
+
+// Import app + auth helpers after mock setup
+import { app } from '../../app';
+import { TEST_JWT_SECRET, authHeader, defaultTestUser } from '../../testHelpers/auth';
+
+// ── Fixtures ───────────────────────────────────────────
+const fakeTag = {
+  id: 'tag_vip_1',
+  name: 'VIP',
+  color: '#FFD700',
+  storeId: 'str_abc123',
+};
+
+const fakeRegularTag = {
+  id: 'tag_reg_1',
+  name: 'Regular',
+  color: '#1E90FF',
+  storeId: 'str_abc123',
+};
+
+const adminAuth = () => authHeader({ role: 'ADMIN' });
+const managerAuth = () => authHeader({ role: 'MANAGER' });
+const staffAuth = () => authHeader({ role: 'STAFF' });
+
+function uniqueViolation(): unknown {
+  const err = new Error(
+    'Unique constraint failed on the fields: (storeId,name)',
+  ) as Error & { code: string; meta?: unknown };
+  err.code = 'P2002';
+  err.meta = { target: ['storeId', 'name'] };
+  return err;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.JWT_SECRET = TEST_JWT_SECRET;
+  // Default to MANAGER so the user can both read AND write tags.
+  mockUser.findUnique.mockResolvedValue({
+    id: defaultTestUser.id,
+    email: defaultTestUser.email,
+    role: 'MANAGER',
+    storeId: defaultTestUser.storeId,
+  });
+});
+
+afterEach(() => {
+  delete process.env.JWT_SECRET;
+});
+
+// ── POST /api/tags ────────────────────────────────────
+describe('POST /api/tags', () => {
+  it('should create a tag and return 201', async () => {
+    mockTag.create.mockResolvedValue(fakeTag);
+
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toEqual(fakeTag);
+  });
+
+  it('should return 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when name is empty string', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: '', color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when name exceeds 50 characters', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'x'.repeat(51), color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for malformed hex color (no #)', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP', color: 'FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for shorthand 3-char hex color', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP', color: '#FFF', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for non-hex characters', async () => {
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP', color: '#GGGGGG', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 409 when tag name already exists in the store', async () => {
+    mockTag.create.mockRejectedValue(uniqueViolation());
+
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CONFLICT');
+    expect(res.body.error.message).toMatch(/already exists/);
+  });
+
+  it('should return 403 when STAFF tries to create a tag', async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role: 'STAFF',
+      storeId: defaultTestUser.storeId,
+    });
+
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', staffAuth())
+      .send({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+});
+
+// ── GET /api/tags ─────────────────────────────────────
+describe('GET /api/tags', () => {
+  it('should return all tags for the requested store', async () => {
+    mockTag.findMany.mockResolvedValue([fakeRegularTag, fakeTag]);
+
+    const res = await request(app)
+      .get('/api/tags?storeId=str_abc123')
+      .set('Authorization', managerAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(mockTag.findMany).toHaveBeenCalledWith({
+      where: { storeId: 'str_abc123' },
+      orderBy: { name: 'asc' },
+    });
+  });
+
+  it('should return 400 when storeId query param is missing', async () => {
+    const res = await request(app)
+      .get('/api/tags')
+      .set('Authorization', managerAuth());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return empty array when store has no tags', async () => {
+    mockTag.findMany.mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/api/tags?storeId=str_empty')
+      .set('Authorization', managerAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('should allow STAFF to read tags', async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role: 'STAFF',
+      storeId: defaultTestUser.storeId,
+    });
+    mockTag.findMany.mockResolvedValue([fakeTag]);
+
+    const res = await request(app)
+      .get('/api/tags?storeId=str_abc123')
+      .set('Authorization', staffAuth());
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── PUT /api/tags/:id ─────────────────────────────────
+describe('PUT /api/tags/:id', () => {
+  it('should update tag name', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockResolvedValue({ ...fakeTag, name: 'VIP+' });
+
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth())
+      .send({ name: 'VIP+' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('VIP+');
+  });
+
+  it('should update tag color', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockResolvedValue({ ...fakeTag, color: '#000000' });
+
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth())
+      .send({ color: '#000000' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.color).toBe('#000000');
+  });
+
+  it('should return 404 when updating non-existent tag', async () => {
+    mockTag.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/tags/nonexistent')
+      .set('Authorization', managerAuth())
+      .send({ name: 'X' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 when body is empty (neither name nor color)', async () => {
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth())
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 for invalid hex color on update', async () => {
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth())
+      .send({ color: 'red' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 409 when renaming to an existing tag name', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockRejectedValue(uniqueViolation());
+
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth())
+      .send({ name: 'Regular' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CONFLICT');
+  });
+
+  it('should return 403 when STAFF tries to update', async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role: 'STAFF',
+      storeId: defaultTestUser.storeId,
+    });
+
+    const res = await request(app)
+      .put('/api/tags/tag_vip_1')
+      .set('Authorization', staffAuth())
+      .send({ name: 'VIP+' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── DELETE /api/tags/:id ──────────────────────────────
+describe('DELETE /api/tags/:id', () => {
+  it('should delete a tag and return 204', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.delete.mockResolvedValue(fakeTag);
+
+    const res = await request(app)
+      .delete('/api/tags/tag_vip_1')
+      .set('Authorization', managerAuth());
+
+    expect(res.status).toBe(204);
+    expect(mockTag.delete).toHaveBeenCalledWith({ where: { id: 'tag_vip_1' } });
+  });
+
+  it('should return 404 when deleting a non-existent tag', async () => {
+    mockTag.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .delete('/api/tags/nonexistent')
+      .set('Authorization', managerAuth());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 403 when STAFF tries to delete', async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role: 'STAFF',
+      storeId: defaultTestUser.storeId,
+    });
+
+    const res = await request(app)
+      .delete('/api/tags/tag_vip_1')
+      .set('Authorization', staffAuth());
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Auth — tag routes ─────────────────────────────────
+describe('Auth — tag routes', () => {
+  it('returns 401 without an Authorization header', async () => {
+    const res = await request(app).get('/api/tags?storeId=str_abc123');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 with an invalid token', async () => {
+    const res = await request(app)
+      .get('/api/tags?storeId=str_abc123')
+      .set('Authorization', 'Bearer invalid.token.here');
+    expect(res.status).toBe(401);
+  });
+
+  it.each([
+    ['ADMIN', adminAuth],
+    ['MANAGER', managerAuth],
+  ])('POST /api/tags allows %s', async (role, makeAuth) => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role,
+      storeId: defaultTestUser.storeId,
+    });
+    mockTag.create.mockResolvedValue(fakeTag);
+
+    const res = await request(app)
+      .post('/api/tags')
+      .set('Authorization', makeAuth())
+      .send({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' });
+
+    expect(res.status).toBe(201);
+  });
+});
+
+// ── POST /api/customers/:id/tags ──────────────────────
+describe('POST /api/customers/:id/tags', () => {
+  it('should assign tags to a customer and return populated tags', async () => {
+    mockCustomer.findFirst.mockResolvedValue({
+      id: 'cus_abc123',
+      storeId: 'str_abc123',
+    });
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }, { id: 'tag_reg_1' }]);
+    mockCustomer.update.mockResolvedValue({
+      tags: [
+        { id: 'tag_vip_1', name: 'VIP', color: '#FFD700' },
+        { id: 'tag_reg_1', name: 'Regular', color: '#1E90FF' },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .set('Authorization', staffAuth())
+      .send({ tagIds: ['tag_vip_1', 'tag_reg_1'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.tags).toHaveLength(2);
+  });
+
+  it('should allow STAFF to assign tags (tags:assign permission)', async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: defaultTestUser.id,
+      email: defaultTestUser.email,
+      role: 'STAFF',
+      storeId: defaultTestUser.storeId,
+    });
+    mockCustomer.findFirst.mockResolvedValue({
+      id: 'cus_abc123',
+      storeId: 'str_abc123',
+    });
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }]);
+    mockCustomer.update.mockResolvedValue({
+      tags: [{ id: 'tag_vip_1', name: 'VIP', color: '#FFD700' }],
+    });
+
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .set('Authorization', staffAuth())
+      .send({ tagIds: ['tag_vip_1'] });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('should return 400 when tagIds is empty', async () => {
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .set('Authorization', staffAuth())
+      .send({ tagIds: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('should return 400 when tagIds is missing', async () => {
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .set('Authorization', staffAuth())
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 404 when customer does not exist', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/customers/nonexistent/tags')
+      .set('Authorization', staffAuth())
+      .send({ tagIds: ['tag_vip_1'] });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('should return 400 when a tagId belongs to a different store', async () => {
+    mockCustomer.findFirst.mockResolvedValue({
+      id: 'cus_abc123',
+      storeId: 'str_abc123',
+    });
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }]); // missing tag_other_store
+
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .set('Authorization', staffAuth())
+      .send({ tagIds: ['tag_vip_1', 'tag_other_store'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.message).toMatch(/tag_other_store/);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app)
+      .post('/api/customers/cus_abc123/tags')
+      .send({ tagIds: ['tag_vip_1'] });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── DELETE /api/customers/:id/tags/:tagId ─────────────
+describe('DELETE /api/customers/:id/tags/:tagId', () => {
+  it('should remove a tag and return remaining tags', async () => {
+    mockCustomer.findFirst.mockResolvedValue({
+      id: 'cus_abc123',
+      storeId: 'str_abc123',
+    });
+    mockCustomer.update.mockResolvedValue({
+      tags: [{ id: 'tag_reg_1', name: 'Regular', color: '#1E90FF' }],
+    });
+
+    const res = await request(app)
+      .delete('/api/customers/cus_abc123/tags/tag_vip_1')
+      .set('Authorization', staffAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.tags).toHaveLength(1);
+    expect(mockCustomer.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cus_abc123' },
+        data: { tags: { disconnect: { id: 'tag_vip_1' } } },
+      }),
+    );
+  });
+
+  it('should return 404 when customer does not exist', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    const res = await request(app)
+      .delete('/api/customers/nonexistent/tags/tag_vip_1')
+      .set('Authorization', staffAuth());
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await request(app).delete(
+      '/api/customers/cus_abc123/tags/tag_vip_1',
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── GET /api/customers/:id (now with populated tags) ──
+describe('GET /api/customers/:id with populated tags', () => {
+  it('should include tags array in the customer response', async () => {
+    mockCustomer.findFirst.mockResolvedValue({
+      id: 'cus_abc123',
+      name: 'John',
+      phone: null,
+      email: null,
+      address: null,
+      notes: null,
+      storeId: 'str_abc123',
+      createdAt: new Date('2026-01-01'),
+      updatedAt: new Date('2026-01-01'),
+      deletedAt: null,
+      tags: [
+        { id: 'tag_vip_1', name: 'VIP', color: '#FFD700' },
+        { id: 'tag_reg_1', name: 'Regular', color: '#1E90FF' },
+      ],
+    });
+
+    const res = await request(app)
+      .get('/api/customers/cus_abc123')
+      .set('Authorization', staffAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.tags).toHaveLength(2);
+    expect(res.body.data.tags[0]).toEqual({
+      id: 'tag_vip_1',
+      name: 'VIP',
+      color: '#FFD700',
+    });
+    // Verify the service called Prisma with the include clause.
+    expect(mockCustomer.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          tags: { select: { id: true, name: true, color: true } },
+        },
+      }),
+    );
+  });
+});

--- a/packages/backend/src/routes/customer.routes.ts
+++ b/packages/backend/src/routes/customer.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import * as customerController from '../controllers/customer.controller';
+import * as tagController from '../controllers/tag.controller';
 import { asyncHandler } from '../utils/asyncHandler';
 import { authenticate } from '../middleware/authenticate';
 import { requirePermission } from '../middleware/authorize';
@@ -16,5 +17,18 @@ router.get('/', requirePermission('customers:read'), asyncHandler(customerContro
 router.get('/:id', requirePermission('customers:read'), asyncHandler(customerController.getById));
 router.put('/:id', requirePermission('customers:write'), asyncHandler(customerController.update));
 router.delete('/:id', requirePermission('customers:write'), asyncHandler(customerController.remove));
+
+// Customer-tag assignment — all roles inside a store may assign/unassign tags
+// (the tag must already exist; CRUD on tags themselves is restricted separately).
+router.post(
+  '/:id/tags',
+  requirePermission('tags:assign'),
+  asyncHandler(tagController.assignToCustomer),
+);
+router.delete(
+  '/:id/tags/:tagId',
+  requirePermission('tags:assign'),
+  asyncHandler(tagController.removeFromCustomer),
+);
 
 export default router;

--- a/packages/backend/src/routes/tag.routes.ts
+++ b/packages/backend/src/routes/tag.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import * as tagController from '../controllers/tag.controller';
+import { asyncHandler } from '../utils/asyncHandler';
+import { authenticate } from '../middleware/authenticate';
+import { requirePermission } from '../middleware/authorize';
+
+const router = Router();
+
+// All tag routes require an authenticated user.
+router.use(asyncHandler(authenticate));
+
+// Reads — every role inside a store.
+router.get('/', requirePermission('tags:read'), asyncHandler(tagController.list));
+
+// Writes — ADMIN and MANAGER only (per the permissions matrix).
+router.post('/', requirePermission('tags:write'), asyncHandler(tagController.create));
+router.put('/:id', requirePermission('tags:write'), asyncHandler(tagController.update));
+router.delete('/:id', requirePermission('tags:write'), asyncHandler(tagController.remove));
+
+export default router;

--- a/packages/backend/src/services/__tests__/customer.service.test.ts
+++ b/packages/backend/src/services/__tests__/customer.service.test.ts
@@ -270,17 +270,32 @@ describe('listCustomers', () => {
 
 // ── getCustomerById ────────────────────────────────────
 describe('getCustomerById', () => {
-  it('should return a customer with tags:[] when found', async () => {
-    mockCustomer.findFirst.mockResolvedValue(fakeCustomer);
+  it('should return a customer with empty tags when none assigned', async () => {
+    mockCustomer.findFirst.mockResolvedValue({ ...fakeCustomer, tags: [] });
 
     const result = await getCustomerById('cus_abc123');
 
     expect(mockCustomer.findFirst).toHaveBeenCalledWith({
       where: { id: 'cus_abc123', deletedAt: null },
+      include: {
+        tags: { select: { id: true, name: true, color: true } },
+      },
     });
     expect(result.id).toBe('cus_abc123');
     expect(result.tags).toEqual([]);
     expect(result).not.toHaveProperty('deletedAt');
+  });
+
+  it('should return populated tags when the customer has tags assigned', async () => {
+    const tags = [
+      { id: 'tag_vip', name: 'VIP', color: '#FFD700' },
+      { id: 'tag_reg', name: 'Regular', color: '#1E90FF' },
+    ];
+    mockCustomer.findFirst.mockResolvedValue({ ...fakeCustomer, tags });
+
+    const result = await getCustomerById('cus_abc123');
+
+    expect(result.tags).toEqual(tags);
   });
 
   it('should throw NotFoundError when customer does not exist', async () => {

--- a/packages/backend/src/services/__tests__/tag.service.test.ts
+++ b/packages/backend/src/services/__tests__/tag.service.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConflictError, NotFoundError, ValidationError } from '../../utils/errors';
+
+// ── Mock Prisma (vi.hoisted so mock is available at hoist time) ──
+const mockTag = vi.hoisted(() => ({
+  create: vi.fn(),
+  findMany: vi.fn(),
+  findUnique: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}));
+
+const mockCustomer = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock('../../prismaClient', () => ({
+  prisma: { tag: mockTag, customer: mockCustomer },
+}));
+
+// Import after mock setup
+import {
+  createTag,
+  listTagsByStore,
+  updateTag,
+  deleteTag,
+  assignTagsToCustomer,
+  removeTagFromCustomer,
+} from '../tag.service';
+
+// ── Fixtures ───────────────────────────────────────────
+const fakeTag = {
+  id: 'tag_vip_1',
+  name: 'VIP',
+  color: '#FFD700',
+  storeId: 'str_abc123',
+};
+
+const fakeRegularTag = {
+  id: 'tag_reg_1',
+  name: 'Regular',
+  color: '#1E90FF',
+  storeId: 'str_abc123',
+};
+
+const fakeCustomerStub = {
+  id: 'cus_abc123',
+  storeId: 'str_abc123',
+};
+
+/**
+ * Mimic a Prisma `PrismaClientKnownRequestError` for unique-constraint
+ * violations without importing the real class (which lives in the
+ * generated client).
+ */
+function uniqueViolation(target: string[] = ['storeId', 'name']): unknown {
+  const err = new Error(
+    `Unique constraint failed on the fields: (${target.join(',')})`,
+  ) as Error & { code: string; meta?: unknown };
+  err.code = 'P2002';
+  err.meta = { target };
+  return err;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── createTag ──────────────────────────────────────────
+describe('createTag', () => {
+  it('should create a tag and return it', async () => {
+    mockTag.create.mockResolvedValue(fakeTag);
+
+    const result = await createTag({
+      name: 'VIP',
+      color: '#FFD700',
+      storeId: 'str_abc123',
+    });
+
+    expect(mockTag.create).toHaveBeenCalledWith({
+      data: { name: 'VIP', color: '#FFD700', storeId: 'str_abc123' },
+    });
+    expect(result).toEqual(fakeTag);
+  });
+
+  it('should throw ConflictError on duplicate tag name in the same store', async () => {
+    mockTag.create.mockRejectedValue(uniqueViolation());
+
+    await expect(
+      createTag({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' }),
+    ).rejects.toThrow(ConflictError);
+    await expect(
+      createTag({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  it('should re-throw unknown errors unchanged', async () => {
+    const dbErr = new Error('connection lost');
+    mockTag.create.mockRejectedValue(dbErr);
+
+    await expect(
+      createTag({ name: 'VIP', color: '#FFD700', storeId: 'str_abc123' }),
+    ).rejects.toThrow('connection lost');
+  });
+});
+
+// ── listTagsByStore ────────────────────────────────────
+describe('listTagsByStore', () => {
+  it('should return all tags for the store sorted by name asc', async () => {
+    mockTag.findMany.mockResolvedValue([fakeRegularTag, fakeTag]);
+
+    const result = await listTagsByStore('str_abc123');
+
+    expect(mockTag.findMany).toHaveBeenCalledWith({
+      where: { storeId: 'str_abc123' },
+      orderBy: { name: 'asc' },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('Regular');
+  });
+
+  it('should return empty array when store has no tags', async () => {
+    mockTag.findMany.mockResolvedValue([]);
+
+    const result = await listTagsByStore('str_empty');
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ── updateTag ──────────────────────────────────────────
+describe('updateTag', () => {
+  it('should update name and return the updated tag', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockResolvedValue({ ...fakeTag, name: 'VIP+' });
+
+    const result = await updateTag('tag_vip_1', { name: 'VIP+' });
+
+    expect(mockTag.update).toHaveBeenCalledWith({
+      where: { id: 'tag_vip_1' },
+      data: { name: 'VIP+' },
+    });
+    expect(result.name).toBe('VIP+');
+  });
+
+  it('should update color', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockResolvedValue({ ...fakeTag, color: '#000000' });
+
+    const result = await updateTag('tag_vip_1', { color: '#000000' });
+
+    expect(result.color).toBe('#000000');
+  });
+
+  it('should throw NotFoundError when tag does not exist', async () => {
+    mockTag.findUnique.mockResolvedValue(null);
+
+    await expect(updateTag('nonexistent', { name: 'X' })).rejects.toThrow(
+      NotFoundError,
+    );
+    expect(mockTag.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw ConflictError when renaming to a name that exists', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.update.mockRejectedValue(uniqueViolation());
+
+    await expect(updateTag('tag_vip_1', { name: 'Regular' })).rejects.toThrow(
+      ConflictError,
+    );
+  });
+});
+
+// ── deleteTag ──────────────────────────────────────────
+describe('deleteTag', () => {
+  it('should delete an existing tag', async () => {
+    mockTag.findUnique.mockResolvedValue(fakeTag);
+    mockTag.delete.mockResolvedValue(fakeTag);
+
+    await deleteTag('tag_vip_1');
+
+    expect(mockTag.delete).toHaveBeenCalledWith({ where: { id: 'tag_vip_1' } });
+  });
+
+  it('should throw NotFoundError when deleting a non-existent tag', async () => {
+    mockTag.findUnique.mockResolvedValue(null);
+
+    await expect(deleteTag('nonexistent')).rejects.toThrow(NotFoundError);
+    expect(mockTag.delete).not.toHaveBeenCalled();
+  });
+});
+
+// ── assignTagsToCustomer ──────────────────────────────
+describe('assignTagsToCustomer', () => {
+  it('should assign tags from the same store and return the updated tag list', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }, { id: 'tag_reg_1' }]);
+    mockCustomer.update.mockResolvedValue({
+      tags: [
+        { id: 'tag_vip_1', name: 'VIP', color: '#FFD700' },
+        { id: 'tag_reg_1', name: 'Regular', color: '#1E90FF' },
+      ],
+    });
+
+    const result = await assignTagsToCustomer('cus_abc123', [
+      'tag_vip_1',
+      'tag_reg_1',
+    ]);
+
+    expect(mockTag.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ['tag_vip_1', 'tag_reg_1'] }, storeId: 'str_abc123' },
+      select: { id: true },
+    });
+    expect(mockCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'cus_abc123' },
+      data: {
+        tags: { connect: [{ id: 'tag_vip_1' }, { id: 'tag_reg_1' }] },
+      },
+      select: {
+        tags: { select: { id: true, name: true, color: true } },
+      },
+    });
+    expect(result).toHaveLength(2);
+  });
+
+  it('should deduplicate tagIds before issuing the query', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }]);
+    mockCustomer.update.mockResolvedValue({ tags: [] });
+
+    await assignTagsToCustomer('cus_abc123', [
+      'tag_vip_1',
+      'tag_vip_1',
+      'tag_vip_1',
+    ]);
+
+    expect(mockTag.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['tag_vip_1'] },
+        }),
+      }),
+    );
+  });
+
+  it('should throw NotFoundError when the customer does not exist', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(
+      assignTagsToCustomer('nonexistent', ['tag_vip_1']),
+    ).rejects.toThrow(NotFoundError);
+    expect(mockCustomer.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundError for a soft-deleted customer', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(
+      assignTagsToCustomer('deleted_cus', ['tag_vip_1']),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('should throw ValidationError when a tagId belongs to a different store', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    // Only one of the two tagIds resolves in this store.
+    mockTag.findMany.mockResolvedValue([{ id: 'tag_vip_1' }]);
+
+    await expect(
+      assignTagsToCustomer('cus_abc123', ['tag_vip_1', 'tag_other_store']),
+    ).rejects.toThrow(ValidationError);
+    await expect(
+      assignTagsToCustomer('cus_abc123', ['tag_vip_1', 'tag_other_store']),
+    ).rejects.toThrow(/tag_other_store/);
+
+    expect(mockCustomer.update).not.toHaveBeenCalled();
+  });
+
+  it('should throw ValidationError when a tagId does not exist at all', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    mockTag.findMany.mockResolvedValue([]);
+
+    await expect(
+      assignTagsToCustomer('cus_abc123', ['ghost_tag']),
+    ).rejects.toThrow(ValidationError);
+  });
+});
+
+// ── removeTagFromCustomer ──────────────────────────────
+describe('removeTagFromCustomer', () => {
+  it('should disconnect the tag and return the updated tag list', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    mockCustomer.update.mockResolvedValue({
+      tags: [{ id: 'tag_reg_1', name: 'Regular', color: '#1E90FF' }],
+    });
+
+    const result = await removeTagFromCustomer('cus_abc123', 'tag_vip_1');
+
+    expect(mockCustomer.update).toHaveBeenCalledWith({
+      where: { id: 'cus_abc123' },
+      data: { tags: { disconnect: { id: 'tag_vip_1' } } },
+      select: {
+        tags: { select: { id: true, name: true, color: true } },
+      },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('tag_reg_1');
+  });
+
+  it('should throw NotFoundError when the customer does not exist', async () => {
+    mockCustomer.findFirst.mockResolvedValue(null);
+
+    await expect(
+      removeTagFromCustomer('nonexistent', 'tag_vip_1'),
+    ).rejects.toThrow(NotFoundError);
+    expect(mockCustomer.update).not.toHaveBeenCalled();
+  });
+
+  it('should be idempotent — removing an unassigned tag still resolves', async () => {
+    mockCustomer.findFirst.mockResolvedValue(fakeCustomerStub);
+    mockCustomer.update.mockResolvedValue({ tags: [] });
+
+    const result = await removeTagFromCustomer('cus_abc123', 'tag_unassigned');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/backend/src/services/customer.service.ts
+++ b/packages/backend/src/services/customer.service.ts
@@ -12,9 +12,20 @@ import { buildPagination } from '../utils/pagination';
 const notDeleted = { deletedAt: null };
 
 /**
- * Shape of a customer as returned from the API. Tags are always
- * included (empty until the tagging system is built in a later
- * milestone) so API consumers can rely on the field existing.
+ * Shape of a tag as it appears inside a customer response — slim, no
+ * `storeId` because the customer already carries that.
+ */
+export interface CustomerTag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+/**
+ * Shape of a customer as returned from the API. The `tags` field is
+ * always present so consumers can rely on it; it is empty for create
+ * / list / update responses (which don't fetch the relation) and
+ * populated for `getCustomerById` (which does).
  */
 export interface CustomerResponse {
   id: string;
@@ -26,7 +37,7 @@ export interface CustomerResponse {
   storeId: string;
   createdAt: Date;
   updatedAt: Date;
-  tags: never[];
+  tags: CustomerTag[];
 }
 
 /** Warning shape returned when a potential duplicate is detected. */
@@ -38,14 +49,19 @@ export interface DuplicateWarning {
 }
 
 /**
- * Attach an empty `tags: []` to a raw Prisma customer object.
- * Strips `deletedAt` so internal fields do not leak through the API.
+ * Normalise a raw Prisma customer object into the API response shape.
+ * Strips `deletedAt` so internal fields do not leak through the API
+ * and ensures `tags` is always an array (defaulting to `[]` when the
+ * caller did not include the relation).
  */
-function toCustomerResponse<T extends { deletedAt?: Date | null }>(
-  customer: T,
-): CustomerResponse {
-  const { deletedAt: _deletedAt, ...rest } = customer;
-  return { ...(rest as unknown as Omit<CustomerResponse, 'tags'>), tags: [] };
+function toCustomerResponse<
+  T extends { deletedAt?: Date | null; tags?: CustomerTag[] },
+>(customer: T): CustomerResponse {
+  const { deletedAt: _deletedAt, tags, ...rest } = customer;
+  return {
+    ...(rest as unknown as Omit<CustomerResponse, 'tags'>),
+    tags: tags ?? [],
+  };
 }
 
 /**
@@ -156,6 +172,9 @@ export async function listCustomers(query: ListCustomersQuery) {
 export async function getCustomerById(id: string): Promise<CustomerResponse> {
   const customer = await prisma.customer.findFirst({
     where: { id, ...notDeleted },
+    include: {
+      tags: { select: { id: true, name: true, color: true } },
+    },
   });
 
   if (!customer) {

--- a/packages/backend/src/services/tag.service.ts
+++ b/packages/backend/src/services/tag.service.ts
@@ -1,0 +1,211 @@
+import { prisma } from '../prismaClient';
+import {
+  CreateTagInput,
+  UpdateTagInput,
+} from '../validators/tag.validator';
+import { ConflictError, NotFoundError, ValidationError } from '../utils/errors';
+
+/**
+ * Shape of a tag as returned from the API. The internal `storeId` is
+ * preserved so the frontend can verify ownership when caching.
+ */
+export interface TagResponse {
+  id: string;
+  name: string;
+  color: string;
+  storeId: string;
+}
+
+/**
+ * Slim shape used inside `customer.tags` — the storeId is implied by
+ * the customer so we omit it to keep the payload small.
+ */
+export interface TagSummary {
+  id: string;
+  name: string;
+  color: string;
+}
+
+/**
+ * Duck-type guard for Prisma's known unique-constraint violation. We avoid
+ * importing `Prisma.PrismaClientKnownRequestError` so this module doesn't
+ * hard-depend on the generated client at compile time.
+ */
+function isUniqueViolation(err: unknown): err is { code: 'P2002' } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'P2002'
+  );
+}
+
+function toTagResponse(tag: {
+  id: string;
+  name: string;
+  color: string;
+  storeId: string;
+}): TagResponse {
+  return {
+    id: tag.id,
+    name: tag.name,
+    color: tag.color,
+    storeId: tag.storeId,
+  };
+}
+
+/**
+ * Create a new tag scoped to a store. Throws `ConflictError` if a tag
+ * with the same name already exists in the store (the unique index
+ * `(storeId, name)` enforces this at the DB level).
+ */
+export async function createTag(data: CreateTagInput): Promise<TagResponse> {
+  try {
+    const tag = await prisma.tag.create({ data });
+    return toTagResponse(tag);
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new ConflictError(
+        `A tag with name '${data.name}' already exists in this store`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * List every tag belonging to a store. Sorted by name (ascending) so
+ * the UI can render a stable, predictable list without extra work.
+ */
+export async function listTagsByStore(storeId: string): Promise<TagResponse[]> {
+  const tags = await prisma.tag.findMany({
+    where: { storeId },
+    orderBy: { name: 'asc' },
+  });
+  return tags.map(toTagResponse);
+}
+
+/**
+ * Update name and/or color of an existing tag. Either field may be
+ * omitted (the validator already enforces "at least one"). Throws:
+ * - `NotFoundError` if the tag does not exist
+ * - `ConflictError` if the new name collides with another tag in the same store
+ */
+export async function updateTag(
+  id: string,
+  data: UpdateTagInput,
+): Promise<TagResponse> {
+  const existing = await prisma.tag.findUnique({ where: { id } });
+  if (!existing) {
+    throw new NotFoundError('Tag', id);
+  }
+
+  try {
+    const updated = await prisma.tag.update({
+      where: { id },
+      data,
+    });
+    return toTagResponse(updated);
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new ConflictError(
+        `A tag with name '${data.name}' already exists in this store`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Delete a tag. Prisma's implicit many-to-many automatically removes
+ * the corresponding rows from the `_CustomerTags` join table — customers
+ * themselves are NOT touched.
+ */
+export async function deleteTag(id: string): Promise<void> {
+  const existing = await prisma.tag.findUnique({ where: { id } });
+  if (!existing) {
+    throw new NotFoundError('Tag', id);
+  }
+
+  await prisma.tag.delete({ where: { id } });
+}
+
+/**
+ * Assign one or more tags to a customer. Validates that:
+ * 1. The customer exists and is not soft-deleted.
+ * 2. Every supplied tagId references a tag that belongs to the same store
+ *    as the customer (cross-store assignment is rejected).
+ *
+ * Returns the updated customer's tags (after assignment).
+ */
+export async function assignTagsToCustomer(
+  customerId: string,
+  tagIds: string[],
+): Promise<TagSummary[]> {
+  const customer = await prisma.customer.findFirst({
+    where: { id: customerId, deletedAt: null },
+    select: { id: true, storeId: true },
+  });
+  if (!customer) {
+    throw new NotFoundError('Customer', customerId);
+  }
+
+  // Deduplicate tagIds so a malicious or sloppy client can't bloat the query.
+  const uniqueTagIds = Array.from(new Set(tagIds));
+
+  // Verify every tag exists AND belongs to the customer's store.
+  const tagsInStore = await prisma.tag.findMany({
+    where: { id: { in: uniqueTagIds }, storeId: customer.storeId },
+    select: { id: true },
+  });
+
+  if (tagsInStore.length !== uniqueTagIds.length) {
+    const foundIds = new Set(tagsInStore.map((t) => t.id));
+    const missing = uniqueTagIds.filter((id) => !foundIds.has(id));
+    throw new ValidationError(
+      `One or more tags do not exist in this store: ${missing.join(', ')}`,
+    );
+  }
+
+  const updated = await prisma.customer.update({
+    where: { id: customerId },
+    data: {
+      tags: { connect: uniqueTagIds.map((id) => ({ id })) },
+    },
+    select: {
+      tags: { select: { id: true, name: true, color: true } },
+    },
+  });
+
+  return updated.tags;
+}
+
+/**
+ * Remove a single tag from a customer. Idempotent: removing a tag that
+ * isn't assigned succeeds silently (Prisma `disconnect` is a no-op in
+ * that case). Returns the updated tag list.
+ */
+export async function removeTagFromCustomer(
+  customerId: string,
+  tagId: string,
+): Promise<TagSummary[]> {
+  const customer = await prisma.customer.findFirst({
+    where: { id: customerId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!customer) {
+    throw new NotFoundError('Customer', customerId);
+  }
+
+  const updated = await prisma.customer.update({
+    where: { id: customerId },
+    data: {
+      tags: { disconnect: { id: tagId } },
+    },
+    select: {
+      tags: { select: { id: true, name: true, color: true } },
+    },
+  });
+
+  return updated.tags;
+}

--- a/packages/backend/src/validators/tag.validator.ts
+++ b/packages/backend/src/validators/tag.validator.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Tag color must be a 6-digit hex string in the form `#RRGGBB`.
+ * Shorthand (#FFF) and named colors are rejected on purpose so the
+ * frontend never has to disambiguate.
+ */
+const hexColorRegex = /^#[0-9A-Fa-f]{6}$/;
+
+export const createTagSchema = z.object({
+  name: z.string().trim().min(1, 'Tag name is required').max(50, 'Tag name must be 50 characters or fewer'),
+  color: z
+    .string()
+    .trim()
+    .regex(hexColorRegex, 'Color must be a hex string in the form #RRGGBB'),
+  storeId: z.string().trim().min(1, 'storeId is required'),
+});
+
+export const updateTagSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, 'Tag name is required')
+      .max(50, 'Tag name must be 50 characters or fewer')
+      .optional(),
+    color: z
+      .string()
+      .trim()
+      .regex(hexColorRegex, 'Color must be a hex string in the form #RRGGBB')
+      .optional(),
+  })
+  .refine((data) => data.name !== undefined || data.color !== undefined, {
+    message: 'At least one of name or color must be provided',
+  });
+
+/**
+ * Body shape for `POST /api/customers/:id/tags` — assign one or more
+ * existing tags to a customer. tagIds must be a non-empty array of
+ * non-empty strings; the service verifies they exist and belong to
+ * the customer's store.
+ */
+export const assignTagsSchema = z.object({
+  tagIds: z
+    .array(z.string().trim().min(1, 'tagId must be non-empty'))
+    .min(1, 'At least one tagId is required'),
+});
+
+/**
+ * Query parameters for `GET /api/tags` — store-scoped listing.
+ */
+export const listTagsQuerySchema = z.object({
+  storeId: z.string().trim().min(1, 'storeId is required'),
+});
+
+export type CreateTagInput = z.infer<typeof createTagSchema>;
+export type UpdateTagInput = z.infer<typeof updateTagSchema>;
+export type AssignTagsInput = z.infer<typeof assignTagsSchema>;
+export type ListTagsQuery = z.infer<typeof listTagsQuerySchema>;


### PR DESCRIPTION
## Summary
- Adds a store-scoped tagging system on top of the `Customer ↔ Tag` many-to-many that #2 already declared.
- New `/api/tags` CRUD plus `POST/DELETE /api/customers/:id/tags[/  :tagId]` for assignment, with `GET /api/customers/:id` now returning a populated `tags: [{id, name, color}]`.
- Tag names are unique within a store via a new migration; predefined seed tags are now **VIP** (gold), **Regular** (blue), **New** (green).

## What changed
**Schema / migration**
- `Tag.@@unique([storeId, name])` so two stores can both have a `VIP` tag, but a single store cannot.
- `20260408000000_add_tag_unique_name_per_store/migration.sql` adds the unique index on the existing `Tag` table.

**Backend**
- `validators/tag.validator.ts` — zod schemas (`name` 1-50, `color` strict `#RRGGBB`, `assignTagsSchema` requires non-empty `tagIds`).
- `services/tag.service.ts` — `createTag` / `listTagsByStore` / `updateTag` / `deleteTag` plus `assignTagsToCustomer` / `removeTagFromCustomer`. P2002 unique violations are mapped to `ConflictError` (409); assignment verifies every `tagId` belongs to the customer's store before connecting.
- `controllers/tag.controller.ts` + `routes/tag.routes.ts` mounted at `/api/tags`. Customer-tag endpoints live under `/api/customers/:id/tags` so they share the customer auth context.
- `customer.service.getCustomerById` now `include`s tags. Other customer endpoints continue to return `tags: []` (they don't fetch the relation, no extra DB cost).
- RBAC reuses the existing matrix: `tags:read` (all roles), `tags:write` (ADMIN/MANAGER), `tags:assign` (all roles).

**Seed**
- `VIP` `#FFD700` · `Regular` `#1E90FF` · `New` `#32CD32`. Existing seed customers re-wired onto the new tag set.

## Test plan
- [x] `npm test -w packages/backend` → **292/292 passing** (38 new tag-route tests, 20 new tag-service tests, plus updated customer.service tests for the new `include` clause)
- [x] `tag.service` coverage: **99% statements / 100% functions** (only the unknown-error rethrow branch is uncovered by design)
- [x] `tsc` clean (`npm run build -w packages/backend`)
- [x] `prisma validate` — schema OK
- [x] `ast-grep` self-check — no `console.log` / `TODO` / hardcoded `localhost` introduced
- [ ] Reviewer to spot-check the migration in a fresh DB if desired (`npm run db:reset`)

## Notes for review
- `isUniqueViolation` is a duck-type guard rather than `instanceof PrismaClientKnownRequestError` so the service module doesn't hard-import the generated Prisma namespace at compile time.
- `removeTagFromCustomer` is intentionally idempotent — disconnect of an unassigned tag is a Prisma no-op and returns the current tag list.
- `assignTagsToCustomer` deduplicates `tagIds` before the store-ownership query so a sloppy/malicious client can't bloat the `IN (...)` clause.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)